### PR TITLE
Add network_connected script to help avoid backing up on mobile data

### DIFF
--- a/hooks/network_connected/README.md
+++ b/hooks/network_connected/README.md
@@ -1,0 +1,16 @@
+# Summary
+
+Script can be used as a pre-hook to verify that Relica's host is connected to a network where it should permit backups (ie wifi not mobile data).
+
+Tested on OSX 10.14
+
+# Usage
+
+Install hook in reasonable location and make executable.
+
+Setup a hook with:
+```
+Timing = Before each destination
+On Error = Stop
+Command = $HOME/bin/network_connected | grep 'MyWifi'
+```

--- a/hooks/network_connected/network_connected
+++ b/hooks/network_connected/network_connected
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -CEeuo pipefail
+IFS=$'\n\t'
+shopt -s extdebug
+
+main() {
+  networksetup -getairportnetwork en0 | sed 's/Current Wi-Fi Network: //g'
+}
+
+main "$@"


### PR DESCRIPTION
@mholt Here you go :). This is the pre-hook I was mentioning for trying to avoid backups that consume lots of data when on mobile hotspot.

Can you please make sure the error codes are being respected? I think I saw an instance where the script should be error coding but I believe it still backed up.

Thanks! Happily using Relica :D.